### PR TITLE
Update to latest spdy version and other various fixes.

### DIFF
--- a/client.js
+++ b/client.js
@@ -40,6 +40,16 @@ client.get = function(options, callback) {
     return client.request(_options, callback);
 }
 
+client.flushConnection = function(host, port, plain) {
+    var key = getKeyFromTarget(host, port, plain);
+    this.connections[key] = null;
+}
+
+var getKeyFromTarget = function(host, port, plain) {
+    var key = (plain ? "http" : "https") + "://" + host + ":" + port;
+    return key;
+}
+
 //
 // ### function getConnection (host, port, plain)
 // #### @host {String} server host
@@ -74,8 +84,11 @@ client.request = function(options, callback) {
     var spdyConnection = this.getConnection(options.host, options.port,
             options.plain);
     /* Do not create new streams after GOAWAY */
-    if (spdyConnection.goAway)
+
+    if (spdyConnection.goAway) {
+        logger.debug('Received GOAWAY, not creating a new stream.');
         return;
+    }
 
     /* second, push the request to the spdy connection */
     return spdyConnection.startRequest(options, callback);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "spdy-client",
+  "version": "0.1.0",
+  "description": "With this module, you can create SPDY clients in node.js. You can send requests to the SPDY server and add listeners for response or data events.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nasss/spdy-client"
+  },
+  "author": "nasss",
+  "readmeFilename": "README.md"
+}


### PR DESCRIPTION
- Add client.flushConnection to allow clients to discard a connection that has
  reached the max number of streams limit.
- Update the code to work with latest node-spdy (1.17.6).
- Add 'connected' event so that clients can determine when they can start sending requests.
- Fix some typos.
- Make sure opened flag is set to false in ClientSpdyConnection.prototype.closeConnection.
- Add package.json file so that spdy-client can be installed using npm (at least locally for now).
